### PR TITLE
move installation from conda_envs to ATBD

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ Copyright (c) 2021, California Institute of Technology ("Caltech"). All rights r
 THIS IS RESEARCH CODE PROVIDED TO YOU "AS IS" WITH NO WARRANTIES OF CORRECTNESS. USE AT YOUR OWN RISK.
 
 ------
-## 1. [Installation](https://github.com/nisar-solid/conda_envs)
+## 1. [Installation](./docs/installation.md)
+
 The dependencies of this ATBD repo is listed in the [requirements.txt](./docs/requirements.txt) file.
-A detailed installation on how to build a working environment using these requirements can be found [here](https://github.com/nisar-solid/conda_envs).
+A detailed installation on how to build a working environment using these requirements can be found [here](./docs/installation.md).
 
 Notes on GPS code installation.
 
 ------
 ## 2. ATBD Jupyter notebooks
+
 The ATBDs for the NISAR Solid Earth L2 requiremetns are included in the xxx folder. A folder breakdown is provided for each requirement.
 
 - Secular Deformation (658) 

--- a/docs/config.rc
+++ b/docs/config.rc
@@ -1,0 +1,39 @@
+# vim: set filetype=sh:
+echo "source ~/tools/ATBD/docs/config.rc"
+
+# root directory
+export TOOL_DIR=~/tools
+export DATA_DIR=~/data   # data / nobak
+
+if [ -z ${PYTHONPATH+x} ]; then export PYTHONPATH=""; fi
+
+##-------------- MintPy / PyAPS / PySolid -------------##
+export MINTPY_HOME=${TOOL_DIR}/MintPy
+export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}:${TOOL_DIR}/PyAPS:${TOOL_DIR}/PySolid
+export PATH=${PATH}:${MINTPY_HOME}/mintpy
+export WEATHER_DIR=${DATA_DIR}/aux
+
+##-------------- ARIA-tools ---------------------------##
+export ARIATOOLS_HOME=${TOOL_DIR}/ARIA-tools/tools
+export PYTHONPATH=${PYTHONPATH}:${ARIATOOLS_HOME}
+export PATH=${PATH}:${ARIATOOLS_HOME}/bin
+
+##-------------- ISCE2 --------------------------------##
+# ISCE_HOME/STACK are set by conda
+export PATH=${PATH}:${ISCE_HOME}/bin:${ISCE_HOME}/applications
+echo "load ISCE-2 core modules installed by conda at "$ISCE_HOME
+
+# common settings (source stack processors and PyCuAmpcor)
+export ISCE_STACK=${TOOL_DIR}/isce2/src/isce2/contrib/stack                     #set ISCE_STACK to the dev version
+export PYTHONPATH=${PYTHONPATH}:${ISCE_STACK}                                   #import tops/stripmapStack as python modules
+export DEMDB=${DATA_DIR}/aux/DEM
+
+# source ONLY ONE AT A TIME to avoid naming conflicts
+alias load_stripmap_stack='export PATH=${PATH}:${ISCE_STACK}/stripmapStack; echo "load ISCE-2 stripmapStack from "${ISCE_STACK}/stripmapStack'
+alias load_tops_stack='export PATH=${PATH}:${ISCE_STACK}/topsStack; echo "load ISCE-2 topsStack from "${ISCE_STACK}/topsStack'
+
+##---------------------- Miscellaneous ----------------##
+export VRT_SHARED_SOURCE=0
+export HDF5_DISABLE_VERSION_CHECK=2    # 0 for abort; 1 for printout warning message; 2 for supress the warning message
+export HDF5_USE_FILE_LOCKING=FALSE
+export OMP_NUM_THREADS=4

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,77 @@
+## Install ATBD
+
+Tested on macOS and Linux, not sure about Windows.
+
+### 1. Install conda
+
+```bash
+mkdir -p ~/tools; cd ~/tools
+
+# download, install and setup (mini/ana)conda
+# for Linux, use Miniconda3-latest-Linux-x86_64.sh
+# for macOS, opt 2: curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o Miniconda3-latest-MacOSX-x86_64.sh
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+chmod +x Miniconda3-latest-MacOSX-x86_64.sh
+./Miniconda3-latest-MacOSX-x86_64.sh -b -p ~/tools/miniconda3
+~/tools/miniconda3/bin/conda init bash
+```
+
+Close and restart the shell for changes to take effect.
+
+```
+conda config --add channels conda-forge
+conda install wget git tree mamba --yes
+```
+
+### 2. Install ATBD, ISCE-2, ARIA-tools and MintPy to `atbd` environment
+
+#### Download source code
+
+```bash
+cd ~/tools
+git clone https://github.com/nisar-solid/ATBD.git
+git clone https://github.com/isce-framework/isce2.git ~/tools/isce2/src/isce2
+git clone https://github.com/aria-tools/ARIA-tools.git
+git clone https://github.com/insarlab/MintPy.git
+git clone https://github.com/insarlab/PySolid.git
+git clone https://github.com/yunjunz/PyAPS.git
+```
+
+#### Create `atbd` environment and install pre-requisites
+
+```bash
+# create new environment
+conda create --name atbd
+conda activate atbd
+
+# install dependencies with conda
+mamba install --yes --file ATBD/docs/requirements.txt --file MintPy/docs/conda.txt --file ARIA-tools/requirements.txt
+
+# install dependencies not available from conda
+ln -s ${CONDA_PREFIX}/bin/cython ${CONDA_PREFIX}/bin/cython3
+$CONDA_PREFIX/bin/pip install git+https://github.com/tylere/pykml.git
+$CONDA_PREFIX/bin/pip install ipynb        # import functions from ipynb files
+
+# compile PySolid
+cd ~/tools/PySolid/pysolid
+f2py -c -m solid solid.for
+```
+
+#### Setup
+
+Create an alias `load_atbd` in `~/.bash_profile` file for easy activation, _e.g._:
+
+```bash
+alias load_atbd='conda activate atbd; source ~/tools/ATBD/docs/config.rc'
+```
+
+#### Test the installation
+
+Run the following to test the installation:
+
+```bash
+load_atbd
+topsApp.py -h
+ariaDownload.py -h
+smallbaselineApp.py -h
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 gdal>=3
 h5py
+isce2
 numpy
 matplotlib
 seaborn


### PR DESCRIPTION
This PR adds the installation notes for ATBD based on conda_envs, so that the former can be independent from conda_envs.

+ Move the following files from conda_envs to ATBD, as discussed in #9 
   - conda_envs/README.md --> ATBD/docs/installation.md
   - conda_envs/insar/config.rc --> ATBD/docs/config.rc

+ rename the custom conda env from 'insar' to 'atbd'
+ use mamba for dependency install to speedup, to replace conda
+ simplify isce2 installation:
   - add isce2 to requirements.txt
   - one line for git clone isce2

After this PR, the conda_envs repo can be archived.