### PR TITLE
gitlab_sync: only run on nisar-solid repo

### DIFF
--- a/.github/workflows/gitlab_sync.yml
+++ b/.github/workflows/gitlab_sync.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   # This workflow contains a single job called "sync"
   sync:
+    # only run on the upstream repo
+    if: github.repository == 'nisar-solid/ATBD'
+
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This PR should adjust the github action of syncing repo to be run only on the `nisar-solid/ATBD` repo, and not on the forked repo.