### PR TITLE
install: install mintpy via `pip install -e`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+methods/*/work/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docs/config.rc
+++ b/docs/config.rc
@@ -12,9 +12,6 @@ export ATBD_HOME=${TOOL_DIR}/ATBD
 export PYTHONPATH=${PYTHONPATH}:${ATBD_HOME}
 
 ##-------------- MintPy -------------------------------##
-export MINTPY_HOME=${TOOL_DIR}/MintPy
-export PYTHONPATH=${PYTHONPATH}:${MINTPY_HOME}
-export PATH=${PATH}:${MINTPY_HOME}/mintpy
 export WEATHER_DIR=${DATA_DIR}/aux
 
 ##-------------- ARIA-tools ---------------------------##
@@ -25,16 +22,7 @@ export PATH=${PATH}:${ARIATOOLS_HOME}/bin
 ##-------------- ISCE2 --------------------------------##
 # ISCE_HOME/STACK are set by conda
 export PATH=${PATH}:${ISCE_HOME}/bin:${ISCE_HOME}/applications
-#echo "load ISCE-2 core modules installed by conda at "$ISCE_HOME
-
-# common settings (source stack processors and PyCuAmpcor)
-export ISCE_STACK=${TOOL_DIR}/isce2/src/isce2/contrib/stack                     #set ISCE_STACK to the dev version
-export PYTHONPATH=${PYTHONPATH}:${ISCE_STACK}                                   #import tops/stripmapStack as python modules
 export DEMDB=${DATA_DIR}/aux/DEM
-
-# source ONLY ONE AT A TIME to avoid naming conflicts
-alias load_stripmap_stack='export PATH=${PATH}:${ISCE_STACK}/stripmapStack; echo "load ISCE-2 stripmapStack from "${ISCE_STACK}/stripmapStack'
-alias load_tops_stack='export PATH=${PATH}:${ISCE_STACK}/topsStack; echo "load ISCE-2 topsStack from "${ISCE_STACK}/topsStack'
 
 ##---------------------- Miscellaneous ----------------##
 export VRT_SHARED_SOURCE=0

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,14 +22,13 @@ conda config --add channels conda-forge
 conda install git mamba --yes
 ```
 
-### 2. Install ATBD, ISCE-2, ARIA-tools and MintPy to `atbd` environment
+### 2. Install ATBD to `atbd` environment
 
 #### Download source code
 
 ```bash
 cd ~/tools
 git clone https://github.com/nisar-solid/ATBD.git
-git clone https://github.com/isce-framework/isce2.git ~/tools/isce2/src/isce2
 git clone https://github.com/aria-tools/ARIA-tools.git
 git clone https://github.com/insarlab/MintPy.git
 ```
@@ -47,6 +46,9 @@ mamba install --yes --file ATBD/requirements.txt --file MintPy/requirements.txt 
 # install dependencies not available from conda
 ln -s ${CONDA_PREFIX}/bin/cython ${CONDA_PREFIX}/bin/cython3
 $CONDA_PREFIX/bin/pip install ipynb        # import functions from ipynb files
+
+# install the development version of mintpy
+$CONDA_PREFIX/bin/pip install -e ~/tools/MintPy
 ```
 
 #### Setup


### PR DESCRIPTION
+ docs/installation.md:
   - install mintpy via pip install -e command, as suggested in the mintpy repo
   - remove git clone isce2 as it's not used anywhere, and it could be easily installed via commenting out isce2 in the requirements.txt file, if needed

+ docs/config.rc
   - remove PATH setup for mintpy, as it is not needed anymore with pip install cmd
   - remove PATH setup for isce2 as it is not used

+ .gitignore: add methods/*/work to ignore data files in the commit by default.