### PR TITLE
Small bug fix in new version of Secular notebook with the improved plotting

### DIFF
--- a/methods/secular/Secular_Requirement_Validation.ipynb
+++ b/methods/secular/Secular_Requirement_Validation.ipynb
@@ -997,6 +997,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# define requirement\n",
+    "secular_insar_rqmt = 2  # mm/yr\n",
+    "insar_dist_rqmt = [0.1, 50.0]  # km\n",
+    "\n",
     "sample_mode = 'profile'  # 'points' or 'profile'\n",
     "# note that the 'profile' method may take significantly longer\n",
     "\n",
@@ -1043,10 +1047,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# define requirement\n",
-    "secular_insar_rqmt = 2  # mm/yr\n",
-    "insar_dist_rqmt = [0.1, 50.0]  # km\n",
-    "\n",
     "# Statistics\n",
     "n_bins = 10\n",
     "threshold = 0.683  \n",
@@ -1302,7 +1302,7 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "insar",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1316,7 +1316,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.10.11"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Quick fix: In the Secular notebook, the variable insar_dist_rqmt is defined in Section 5.3 but used in Section 5.2. I moved the requirement definitions to Section 5.2 to avoid errors.