### PR TITLE
remove mintpy version from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ gdal>=3
 h5py
 #isce2
 matplotlib
-mintpy=1.4.1
+mintpy
 numpy
 scipy
 wget


### PR DESCRIPTION
The requirements.txt file had specified a very old version of MintPy.