### PR TITLE
add option to change/reselect reference point

### DIFF
--- a/methods/coseismic/Coseismic_Requirement_Validation.ipynb
+++ b/methods/coseismic/Coseismic_Requirement_Validation.ipynb
@@ -299,6 +299,61 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2.1 Change Reference Point (Optional) <a id='common_latlon_change'></a>\n",
+    "\n",
+    "Use the cells below to update the reference point. Uncomment and enter the desired *new_lat* and *new_lon*, then verify the update in the output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# def update_reference_point(config_file, new_lat, new_lon):\n",
+    "#     # Read the file\n",
+    "#     with open(config_file, \"r\") as file:\n",
+    "#         lines = file.readlines()\n",
+    "    \n",
+    "#     # Update the specific key\n",
+    "#     for i, line in enumerate(lines):\n",
+    "#         if \"mintpy.reference.lalo\" in line:\n",
+    "#             lines[i] = f\"mintpy.reference.lalo = {new_lat}, {new_lon}\\n\"\n",
+    "#             break  # Stop after updating the line\n",
+    "    \n",
+    "#     # Write back the modified file\n",
+    "#     with open(config_file, \"w\") as file:\n",
+    "#         file.writelines(lines)\n",
+    "    \n",
+    "#     print(f\"Updated mintpy.reference.lalo to {new_lat}, {new_lon}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# new_lat =\n",
+    "# new_lon = \n",
+    "# update_reference_point(config_file, new_lat, new_lon)  # New latitude and longitude"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# command = 'smallbaselineApp.py ' + str(config_file) + ' --dostep reference_point'\n",
+    "# process = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, shell=True)\n",
+    "# os.system('info.py inputs/ifgramStack.h5 | egrep \"REF_\"');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "tags": []
    },
@@ -2031,7 +2086,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.12.8"
   },
   "toc-autonumbering": false,
   "toc-showcode": false,


### PR DESCRIPTION
Added a new subsection to change reference point latitude and longitude in the config file. This change removes the need to re-run the `prep` notebook to change reference point.