### PR TITLE
clean up unused modules

### DIFF
--- a/prep/ARIA_prep.ipynb
+++ b/prep/ARIA_prep.ipynb
@@ -68,26 +68,10 @@
    },
    "outputs": [],
    "source": [
-    "import glob\n",
     "import json\n",
     "import netrc\n",
-    "import numpy as np\n",
     "import os\n",
-    "import pandas as pd\n",
-    "import subprocess\n",
-    "\n",
-    "from datetime import datetime as dt\n",
-    "from matplotlib import pyplot as plt\n",
-    "from mintpy.cli import view, plot_network\n",
-    "from mintpy.objects import gnss, timeseries\n",
-    "from mintpy.smallbaselineApp import TimeSeriesAnalysis\n",
-    "from mintpy.utils import ptime, readfile, utils as ut\n",
-    "from pathlib import Path\n",
-    "from scipy import signal\n",
-    "from solid_utils.sampling import load_geo, samp_pair, profile_samples, haversine_distance\n",
-    "\n",
-    "# Set gobal plot parameters\n",
-    "plt.rcParams.update({'font.size': 12})"
+    "import subprocess"
    ]
   },
   {
@@ -123,7 +107,7 @@
     "aria_gunw_version = '3_0_1'\n",
     "\n",
     "# The date and version of this Cal/Val run\n",
-    "rundate = '20250214'\n",
+    "rundate = '20250311'\n",
     "version = '1'\n",
     "\n",
     "# Provide the file where you keep your customized list of sites.\n",
@@ -186,7 +170,7 @@
     "print(\"MintPy directory:\", mintpy_dir)\n",
     "\n",
     "# Configuration file\n",
-    "config_file = Path(mintpy_dir)/(sitedata['sites'][site]['calval_location'] + '.cfg')"
+    "config_file = os.path.join(mintpy_dir, sitedata['sites'][site]['calval_location'] + '.cfg')"
    ]
   },
   {
@@ -454,9 +438,14 @@
     "                                enddatevel=sitedata['sites'][site]['download_end_date'],\n",
     "                                reference_lalo=sitedata['sites'][site]['reference_lalo'])\n",
     "\n",
-    "config_file.write_text(config_file_content)\n",
-    "print('MintPy config file:\\n    {}'.format(config_file))\n",
-    "print(config_file.read_text())"
+    "# Write the config file\n",
+    "with open(config_file, \"w\") as file:\n",
+    "    file.write(config_file_content)\n",
+    "\n",
+    "# Print the results\n",
+    "print(f'MintPy config file:\\n    {config_file}')\n",
+    "with open(config_file, \"r\") as file:\n",
+    "    print(file.read())"
    ]
   },
   {
@@ -489,9 +478,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:.local-solid_earth_atbd]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-.local-solid_earth_atbd-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -503,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Remove unused modules to remove unnecessary dependency. `Path` from `pathlib` module was only used once so I replaced it with `os` module functionality to be consistent with the rest of the notebook.
