### PR TITLE
Split reference point with comma

### DIFF
--- a/methods/coseismic/Coseismic_Requirement_Validation.ipynb
+++ b/methods/coseismic/Coseismic_Requirement_Validation.ipynb
@@ -357,8 +357,8 @@
    "outputs": [],
    "source": [
     "if sitedata['sites'][site]['reference_lalo'].strip() != 'auto':\n",
-    "    new_lat = sitedata['sites'][site]['reference_lalo'].strip().split()[0]\n",
-    "    new_lon = sitedata['sites'][site]['reference_lalo'].strip().split()[1]\n",
+    "    new_lat = sitedata['sites'][site]['reference_lalo'].strip().split(',')[0]\n",
+    "    new_lon = sitedata['sites'][site]['reference_lalo'].strip().split(',')[1]\n",
     "    update_reference_point(config_file, new_lat, new_lon)  # New latitude and longitude\n",
     "\n",
     "    command = 'smallbaselineApp.py ' + str(config_file) + ' --dostep reference_point'\n",

--- a/methods/secular/Secular_Requirement_Validation.ipynb
+++ b/methods/secular/Secular_Requirement_Validation.ipynb
@@ -329,8 +329,8 @@
    "source": [
     "if sitedata['sites'][site]['reference_lalo'].strip() != 'auto':\n",
     "    # Check the reference point in the my_sites file, to see if it has changed\n",
-    "    new_lat = sitedata['sites'][site]['reference_lalo'].strip().split()[0]\n",
-    "    new_lon = sitedata['sites'][site]['reference_lalo'].strip().split()[1]\n",
+    "    new_lat = sitedata['sites'][site]['reference_lalo'].strip().split(',')[0]\n",
+    "    new_lon = sitedata['sites'][site]['reference_lalo'].strip().split(',')[1]\n",
     "    update_reference_point(config_file, new_lat, new_lon)  # New latitude and longitude\n",
     "    \n",
     "# Now reference interferograms to common lat/lon\n",


### PR DESCRIPTION
When reference points are read in, Python did not split the lat/lon values of a user-specified reference point.
This PR explicitly specifies a comma as the lat/lon separator, as is encoded in the my_sites file.