### PR TITLE
Add hyp3-sdk and sardem to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 gdal>=3
 h5py
+hyp3-sdk
 #isce2
 matplotlib
 mintpy
@@ -16,3 +17,4 @@ nbdime
 geopandas
 pandas
 rasterio
+sardem


### PR DESCRIPTION
hyp3-sdk is used in the permafrost notebook.
sardem is a tool to download and create DEMs with a bounding box from multiple sources to choose from.